### PR TITLE
Fix WHOIS and RDAP to correctly extract the TLD for multi-segment TLDs

### DIFF
--- a/rdap/start_rdap.php
+++ b/rdap/start_rdap.php
@@ -227,7 +227,13 @@ function handleDomainQuery($request, $response, $pdo, $domainName, $c, $log) {
     
     // Extract TLD from the domain
     $parts = explode('.', $domain);
-    $tld = "." . end($parts);
+    
+    // Handle multi-segment TLDs (e.g., co.uk, ngo.us, etc.)
+    if (count($parts) > 2) {
+        $tld = "." . $parts[count($parts) - 2] . "." . $parts[count($parts) - 1];
+    } else {
+        $tld = "." . end($parts);
+    }
 
     // Check if the TLD exists in the domain_tld table
     $stmtTLD = $pdo->prepare("SELECT COUNT(*) FROM domain_tld WHERE tld = :tld");

--- a/whois/port43/start_whois.php
+++ b/whois/port43/start_whois.php
@@ -111,7 +111,13 @@ $server->on('receive', function ($server, $fd, $reactorId, $data) use ($c, $pool
             
                 // Extract TLD from the domain and prepend a dot
                 $parts = explode('.', $domain);
-                $tld = "." . end($parts);
+                
+                // Handle multi-segment TLDs (e.g., co.uk, ngo.us, etc.)
+                if (count($parts) > 2) {
+                    $tld = "." . $parts[count($parts) - 2] . "." . $parts[count($parts) - 1];
+                } else {
+                    $tld = "." . end($parts);
+                }
 
                 // Check if the TLD exists in the domain_tld table
                 $stmtTLD = $pdo->prepare("SELECT COUNT(*) FROM domain_tld WHERE tld = :tld");


### PR DESCRIPTION
In this pull request, the logic for extracting the top-level domain (TLD) from a given domain has been revised to correctly handle multi-segment TLDs (e.g., `ngo.us`, `co.uk`), aka, SLDs.

Previously, the code only considered the final segment of the domain, which caused issues when validating multi-segment TLDs. 

Incorrect output:

```sh
$ whois -h whois.ngo.us example.ngo.us
Invalid TLD. Please search only allowed TLDs
```

The updated code now checks if the domain consists of more than two parts and, if so, concatenates the last two segments to form the TLD. This ensures that domains like `example.ngo.us` are correctly validated against the `domain_tld` table, preventing erroneous "Invalid TLD" messages.

Corrected output:

```sh
$ whois -h whois.ngo.us example.ngo.us
Registry Domain ID: D2-NGOUS
Registrar WHOIS Server: whois.ngo.us
Registrar URL: https://client.ngo.us

...

```
